### PR TITLE
Sd release

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -26,4 +26,5 @@ jobs:
           npx semantic-release --dry-run
     secrets:
       - NPM_TOKEN
+      - GH_TOKEN
       - GIT_KEY_BASE64


### PR DESCRIPTION
>**Note:** SSH keys allow to push the [Git release tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated to the released version. Some plugins might also require an API token. See each plugin documentation for additional information.

https://github.com/semantic-release/semantic-release/pull/783/files