### PR TITLE
ci: Remove semantic-release dry-run

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,7 +23,7 @@ jobs:
       - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git /tmp/ci
       - publish: |
           . /tmp/ci/git-ssh.sh
-          npx semantic-release --dry-run
+          npx semantic-release
     secrets:
       - NPM_TOKEN
       - GH_TOKEN


### PR DESCRIPTION
<img width="1210" alt="Screen Shot 2020-05-22 at 9 57 34 AM" src="https://user-images.githubusercontent.com/2983409/82681332-3ffbce00-9c13-11ea-874b-fe6292f408af.png">

https://cd.screwdriver.cd/pipelines/4792/builds/274309/steps/publish