### PR TITLE
build: Set npm access level to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
       }
     ]
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": "10.* || >= 12"
   },


### PR DESCRIPTION
https://github.com/semantic-release/semantic-release/blob/master/docs/support/FAQ.md#how-can-i-set-the-access-level-of-the-published-npm-package