### PR TITLE
ci: set git fetch to ssh url for storybook

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -36,6 +36,7 @@ jobs:
       - install: npm ci
       - docs: |
           . /tmp/ci/git-ssh.sh
+          git remote set-url origin `git remote get-url --push origin`
           npm run deploy-storybook
     secrets:
       - GIT_KEY_BASE64


### PR DESCRIPTION
SD sets the git fetch remote as a http url. Storybook deployer uses that to push:

https://github.com/storybookjs/storybook-deployer/blob/master/bin/storybook_to_ghpages#L16

In order to use our ssh keys, we need to use the ssh url.