### PR TITLE
Power select sizes, groups, Input wrapper, tag updates, and DenaliSelect Sizes

### DIFF
--- a/addon/components/denali-input.hbs
+++ b/addon/components/denali-input.hbs
@@ -5,7 +5,9 @@
   {{this.inverseClass}}
   {{this.sizeClass}}
   {{this.activeClass}}
-  {{this.errorClass}}"
+  {{this.errorClass}}
+  {{this.wrapperClass}}
+  "
 >
   {{#if @iconFront}}
     <span class="d-icon d-{{@iconFront}} {{this.iconFrontClass}}"></span>

--- a/addon/components/denali-input.js
+++ b/addon/components/denali-input.js
@@ -32,6 +32,9 @@ export default class DenaliInputComponent extends Component {
   @arg(string)
   errorMsg;
 
+  @arg(string)
+  wrapperClass;
+
   get sizeClass() {
     return this.size ? `is-${this.size}` : undefined;
   }

--- a/addon/components/denali-select-enums.js
+++ b/addon/components/denali-select-enums.js
@@ -1,0 +1,5 @@
+/**
+ * Copyright 2021, Verizon Media
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+export const SIZES = ['small', 'medium', 'large'];

--- a/addon/components/denali-select.hbs
+++ b/addon/components/denali-select.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2020, Verizon Media. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="input has-arrow {{this.isSmallClass}} {{this.isInverseClass}}">
+<div class="input has-arrow {{this.sizeClass}} {{this.isInverseClass}}">
   <select {{on "change" this.onSelect}} ...attributes>
     {{#each this.options as |opt|}}
       <option

--- a/addon/components/denali-select.js
+++ b/addon/components/denali-select.js
@@ -4,12 +4,13 @@
  */
 import Component from '@glimmer/component';
 import { arg } from 'ember-arg-types';
-import { func, boolean, array, any } from 'prop-types';
+import { func, boolean, array, any, oneOf } from 'prop-types';
 import { action } from '@ember/object';
+import { SIZES } from './denali-select-enums';
 
 export default class DenaliSelectComponent extends Component {
-  @arg(boolean)
-  isSmall = false;
+  @arg(oneOf(SIZES))
+  size;
 
   @arg(boolean)
   isInverse = false;
@@ -31,8 +32,8 @@ export default class DenaliSelectComponent extends Component {
     this.onChange(this.options[e.target.selectedIndex]);
   }
 
-  get isSmallClass() {
-    return this.isSmall ? 'is-small' : undefined;
+  get sizeClass() {
+    return this.size ? `is-${this.size}` : undefined;
   }
 
   get isInverseClass() {

--- a/addon/components/denali-tag.hbs
+++ b/addon/components/denali-tag.hbs
@@ -9,12 +9,12 @@
   ...attributes
 >
   {{#if this.iconFront}}
-    <i class="d-icon d-{{this.iconFront}}" />
+    <i class="d-icon d-{{this.iconFront}} {{this.iconFrontClass}}" {{on "click" this.onIconFrontClick}}/>
   {{/if}}
 
   {{yield}}
 
   {{#if this.iconBack}}
-    <i class="d-icon d-{{this.iconBack}}" />
+    <i class="d-icon d-{{this.iconBack}} {{this.iconBackClass}}" {{on "click" this.onIconBackClick}} />
   {{/if}}
 </span>

--- a/addon/components/denali-tag.js
+++ b/addon/components/denali-tag.js
@@ -4,7 +4,7 @@
  */
 import Component from '@glimmer/component';
 import { arg } from 'ember-arg-types';
-import { oneOf, boolean, string } from 'prop-types';
+import { oneOf, boolean, string, func } from 'prop-types';
 import { STATES } from './denali-tag-enums';
 
 export default class DenaliTagComponent extends Component {
@@ -22,6 +22,18 @@ export default class DenaliTagComponent extends Component {
 
   @arg(string)
   iconBack;
+
+  @arg(string)
+  iconFrontClass;
+
+  @arg(string)
+  iconBackClass;
+
+  @arg(func)
+  onIconFrontClick = () => null;
+
+  @arg(func)
+  onIconBackClick = () => null;
 
   get isActiveClass() {
     return this.state === 'active' ? 'is-active' : undefined;

--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -3,36 +3,6 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-.ember-basic-dropdown {
-  &.is-large {
-    .ember-power-select-trigger {
-      min-height: $fields-sizes-lg-height;
-    }
-  }
-  &.is-medium {
-    .ember-power-select-trigger {
-      min-height: $fields-sizes-md-height;
-    }
-    .ember-power-select-multiple-option {
-      font-size: $tags-small-text-size;
-      height: $tags-small-height;
-      margin: 3px 3px 3px 0;
-      padding: $tags-small-padding;
-    }
-  }
-  &.is-small {
-    .ember-power-select-trigger {
-      min-height: $fields-sizes-sm-height;
-    }
-    .ember-power-select-multiple-option {
-      font-size: $tags-small-text-size;
-      height: 18px;
-      margin: 2px 3px 2px 0;
-      padding: $tags-small-padding;
-    }
-  }
-}
-
 .ember-power-select-trigger {
   align-items: center;
   background: $fields-default-bg;
@@ -42,8 +12,7 @@
   display: flex;
   min-height: $fields-sizes-default-height;
   outline: none;
-  padding-left: 10px;
-  padding-right: 25px;
+  padding: 2px 25px 2px 10px;
   position: relative;
   &:before {
     content: url('data:image/svg+xml;charset=UTF-8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path style="fill:#{$fields-dropdown-arrow-color}" d="M24,27.17,13.4,16.59a2,2,0,0,0-3.05.25,2.07,2.07,0,0,0,.3,2.65L22.59,31.41a2,2,0,0,0,2.83,0L37.35,19.49a2.07,2.07,0,0,0,.3-2.65,2,2,0,0,0-3-.25Z"/></svg>');
@@ -56,14 +25,50 @@
     right: 10px;
     width: 18px;
   }
+
   &--active {
     box-shadow: $fields-focus-border;
+  }
+
+  &[aria-disabled='true'] {
+    background: $fields-disabled-bg;
+  }
+
+  &.is-large {
+    min-height: $fields-sizes-lg-height;
+  }
+
+  &.is-medium {
+    min-height: $fields-sizes-md-height;
+
+    .ember-power-select-multiple-option {
+      font-size: $tags-small-text-size;
+      height: $tags-small-height;
+      margin: 3px 3px 3px 0;
+      padding: $tags-small-padding;
+    }
+  }
+
+  &.is-small {
+    min-height: $fields-sizes-sm-height;
+
+    .ember-power-select-multiple-option {
+      font-size: $tags-small-text-size;
+      height: 18px;
+      margin: 2px 3px 2px 0;
+      padding: $tags-small-padding;
+    }
   }
 }
 
 .ember-power-select-multiple-options {
   display: flex;
   flex-wrap: wrap;
+}
+
+.ember-power-select-options {
+  max-height: 12em;
+  overflow-x: auto;
 }
 
 .ember-power-select-multiple-option {
@@ -77,6 +82,23 @@
   background-color: transparent;
   border: none;
   outline: none;
+}
+
+.ember-power-select-group {
+  .ember-power-select-option {
+    padding: 8px 16px;
+  }
+}
+
+.ember-power-select-group-name {
+  display: block;
+  padding: 8px;
+}
+
+.ember-power-select-group-name {
+  text-transform: uppercase;
+  color: $color-grey-700;
+  font-size: 12px;
 }
 
 .ember-power-select-option {

--- a/stories/button.stories.js
+++ b/stories/button.stories.js
@@ -27,6 +27,8 @@ export const Playground = () => ({
       @size={{size}}
       @isFull={{isFull}}
       @style={{style}}
+      @icon={{icon}}
+      @iconOnly={{iconOnly}}
       @type={{type}}
       disabled={{disabled}}
       class={{class}}
@@ -42,6 +44,8 @@ export const Playground = () => ({
     size: select('size', SIZES, SIZES[0], argument),
     isFull: boolean('isFull', false, argument),
     style: select('style', STYLES, STYLES[0], argument),
+    icon: text('icon', '', argument),
+    iconOnly: boolean('iconOnly', false, argument),
     type: select('type', TYPES, TYPES[0], argument),
     class: text('class', '', attribute),
     disabled: boolean('disabled', false, attribute),

--- a/stories/ember-power-select/power-select-multiple.stories.js
+++ b/stories/ember-power-select/power-select-multiple.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, array, select } from '@storybook/addon-knobs';
+import { withKnobs, array, boolean, select } from '@storybook/addon-knobs';
 import { example } from '../knob-categories';
 
 export default {
@@ -32,16 +32,41 @@ export const Default = () => ({
   },
 });
 
-export const Playground = () => ({
+export const Groups = () => ({
   template: hbs`
     <PowerSelectMultiple
       @searchEnabled={{true}}
+      @searchField="name"
       @options={{items}}
       @selected={{selectedItems}}
       @placeholder="Select Some Items..."
       @onChange={{queue onChange (fn (mut selectedItems))}}
       @renderInPlace={{true}}
-      class={{sizeClass}}
+      as |item|
+    >
+      {{item}}
+    </PowerSelectMultiple>
+  `,
+  context: {
+    items: [
+      { groupName: 'Denali', options: ['Themable', 'Design', 'System'] },
+      { groupName: 'Ember', options: ['Ambitious', 'Web', 'Framework'] },
+    ],
+    onChange: action('onChange'),
+  },
+});
+
+export const Playground = () => ({
+  template: hbs`
+    <PowerSelectMultiple
+      @options={{items}}
+      @selected={{selectedItems}}
+      @searchEnabled={{true}}
+      @placeholder="Select Some Items..."
+      @disabled={{disabled}}
+      @onChange={{queue onChange (fn (mut selectedItems))}}
+      @renderInPlace={{true}}
+      @triggerClass={{sizeClass}}
       as |name|
     >
       {{name}}
@@ -50,6 +75,7 @@ export const Playground = () => ({
   context: {
     items: array('items', ['Denali', 'Styled', 'Power', 'Select', 'Multiple'], ',', example),
     selectedItems: array('selectedItems', ['Denali'], ',', example),
+    disabled: boolean('disabled', false, example),
     sizeClass: select('sizeClass', [undefined, 'is-small', 'is-medium', 'is-large'], undefined, example),
     onChange: action('onChange'),
   },

--- a/stories/ember-power-select/power-select.stories.js
+++ b/stories/ember-power-select/power-select.stories.js
@@ -33,26 +33,53 @@ export const Default = () => ({
   },
 });
 
-export const Playground = () => ({
+export const Groups = () => ({
   template: hbs`
     <PowerSelect
-      @searchEnabled={{enableSearch}}
-      @searchPlaceholder="Search"
+      @searchEnabled={{searchEnabled}}
       @options={{items}}
       @selected={{selectedItem}}
+      @searchPlaceholder="Search"
       @placeholder="Select An Item..."
       @onChange={{queue onChange (fn (mut selectedItem))}}
       @renderInPlace={{true}}
-      class={{sizeClass}}
+      as |item|
+    >
+      {{item}}
+    </PowerSelect>
+  `,
+  context: {
+    items: [
+      { groupName: 'Denali', options: ['Themable', 'Design', 'System'] },
+      { groupName: 'Ember', options: ['Ambitious', 'Web', 'Framework'] },
+    ],
+    onChange: action('onChange'),
+    searchEnabled: boolean('searchEnabled', true, example),
+  },
+});
+
+export const Playground = () => ({
+  template: hbs`
+    <PowerSelect
+      @options={{items}}
+      @selected={{selectedItem}}
+      @searchEnabled={{searchEnabled}}
+      @searchPlaceholder="Search"
+      @placeholder="Select An Item..."
+      @disabled={{disabled}}
+      @onChange={{queue onChange (fn (mut selectedItem))}}
+      @renderInPlace={{true}}
+      @triggerClass={{sizeClass}}
       as |name|
     >
       {{name}}
     </PowerSelect>
   `,
   context: {
-    enableSearch: boolean('enableSearch', true, example),
     items: array('items', ['Denali', 'Styled', 'Power', 'Select', 'Multiple'], ',', example),
     selectedItem: text('selectedItem', 'Denali', example),
+    searchEnabled: boolean('searchEnabled', true, example),
+    disabled: boolean('disabled', false, example),
     sizeClass: select('sizeClass', [undefined, 'is-small', 'is-medium', 'is-large'], undefined, example),
     onChange: action('onChange'),
   },

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -27,6 +27,7 @@ export const Playground = () => ({
       @iconFrontClass={{iconFrontClass}}
       @iconBackClass={{iconBackClass}}
       @errorMsg={{errorMsg}}
+      @wrapperClass={{wrapperClass}}
       value={{value}}
       placeholder={{placeholder}}
       disabled={{disabled}}
@@ -44,6 +45,7 @@ export const Playground = () => ({
     iconFrontClass: text('iconFrontClass', '', argument),
     iconBackClass: text('iconBackClass', 'is-brand-300', argument),
     errorMsg: text('errMsg', '', argument),
+    wrapperClass: text('wrapperClass', '', argument),
     value: text('value', '', attribute),
     placeholder: text('placeholder', 'Search', attribute),
     disabled: boolean('disabled', false, attribute),

--- a/stories/select.stories.js
+++ b/stories/select.stories.js
@@ -1,7 +1,8 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, array, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, array, boolean, select, text } from '@storybook/addon-knobs';
 import { argument, attribute, example } from './knob-categories';
+import { SIZES } from '../addon/components/denali-select-enums';
 
 export default {
   title: 'DenaliSelect',
@@ -26,13 +27,15 @@ export const Default = () => ({
   },
 });
 
+const allSizes = [undefined, ...SIZES];
+
 export const Playground = () => ({
   template: hbs`
     <DenaliSelect
       @options={{items}}
       @selectedOption={{selectedItem}}
       @disabledOptions={{disabledItems}}
-      @isSmall={{isSmall}}
+      @size={{size}}
       @isInverse={{isInverse}}
       @onChange={{queue onChange (fn (mut selectedItem))}}
       class={{class}}
@@ -41,7 +44,7 @@ export const Playground = () => ({
     </DenaliSelect>
   `,
   context: {
-    isSmall: boolean('isSmall', false, argument),
+    size: select('size', allSizes, allSizes[0], argument),
     isInverse: boolean('isInverse', false, argument),
     class: text('class', '', attribute),
     items: array('items', ['Ember', 'Denali', 'Select'], ',', example),

--- a/stories/tag.stories.js
+++ b/stories/tag.stories.js
@@ -1,4 +1,5 @@
 import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
 import { withKnobs, array, boolean, select, text } from '@storybook/addon-knobs';
 import { argument, attribute, example } from './knob-categories';
 import { STATES } from '../addon/components/denali-tag-enums';
@@ -26,7 +27,11 @@ export const Playground = () => ({
         @isSmall={{isSmall}}
         @isOutlined={{isOutlined}}
         @iconFront={{iconFront}}
+        @iconFrontClass={{iconFrontClass}}
+        @onIconFrontClick={{onIconFrontClick}}
         @iconBack={{iconBack}}
+        @iconBackClass={{iconBackClass}}
+        @onIconBackClick={{onIconBackClick}}
         class={{class}}
       >
         {{item}}
@@ -38,7 +43,11 @@ export const Playground = () => ({
     isSmall: boolean('isSmall', false, argument),
     isOutlined: boolean('isOutlined', false, argument),
     iconFront: text('iconFront', '', argument),
+    iconFrontClass: text('iconFrontClass', '', argument),
+    onIconFrontClick: action('onIconFrontClick'),
     iconBack: text('iconBack', 'close', argument),
+    iconBackClass: text('iconBackClass', '', argument),
+    onIconBackClick: action('onIconBackClick'),
     items: array('items', ['Ember', 'Denali', 'Tags'], ',', example),
     class: text('class', '', attribute),
   },

--- a/tests/integration/components/denali-input-test.js
+++ b/tests/integration/components/denali-input-test.js
@@ -7,8 +7,6 @@ module('Integration | Component | denali-input', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    assert.expect(3);
-
     await render(hbs`<DenaliInput value="My Input" />`);
 
     assert.dom('.input input').exists('An input is rendered within a wrapper div with class `.input`');
@@ -17,8 +15,6 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('input types', async function (assert) {
-    assert.expect(4);
-
     await render(hbs`<DenaliInput type={{this.type}}/>`);
 
     this.set('type', 'text');
@@ -35,8 +31,6 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('input size', async function (assert) {
-    assert.expect(2);
-
     await render(hbs`<DenaliInput @size={{this.size}} />`);
     this.set('size', 'small');
     assert.dom('.input').hasClass('is-small', 'The input wrapper has the appropriate class for small');
@@ -46,8 +40,6 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('states', async function (assert) {
-    assert.expect(2);
-
     await render(hbs`<DenaliInput @state={{this.state}} />`);
 
     this.set('state', 'active');
@@ -58,22 +50,16 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('disabled', async function (assert) {
-    assert.expect(1);
-
     await render(hbs`<DenaliInput disabled={{true}}/>`);
     assert.dom('.input input').isDisabled('The input is disabled when specified');
   });
 
   test('placeholder', async function (assert) {
-    assert.expect(1);
-
     await render(hbs`<DenaliInput type="email" placeholder="Email field"/>`);
     assert.dom('.input input').hasAttribute('placeholder', 'Email field', 'The input is has the specified placeholder');
   });
 
   test('is inverse', async function (assert) {
-    assert.expect(2);
-
     await render(hbs`<DenaliInput @isInverse={{this.isInverse}} />`);
     assert.dom('.input').doesNotHaveClass('is-inverse', 'The input wrapper by default does not have the inverse class');
 
@@ -82,8 +68,6 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('error message', async function (assert) {
-    assert.expect(2);
-
     await render(hbs`<DenaliInput @state="error" @errorMsg={{this.errorMsg}} />`);
     assert.dom('.input.is-error .message').doesNotExist();
 
@@ -92,14 +76,14 @@ module('Integration | Component | denali-input', function (hooks) {
   });
 
   test('icons', async function (assert) {
-    assert.expect(6);
-
-    await render(hbs`<DenaliInput
-      @iconFront={{this.iconFront}}
-      @iconFrontClass="front-icon"
-      @iconBack={{this.iconBack}}
-      @iconBackClass="back-icon"
-    />`);
+    await render(hbs`
+      <DenaliInput
+        @iconFront={{this.iconFront}}
+        @iconFrontClass="front-icon"
+        @iconBack={{this.iconBack}}
+        @iconBackClass="back-icon"
+      />
+    `);
 
     assert
       .dom('.input.has-icon-front')
@@ -123,6 +107,21 @@ module('Integration | Component | denali-input', function (hooks) {
     assert
       .dom('.input.has-icon-back .back-icon')
       .hasClass('d-close-circle-solid', 'The correct denali icon is rendered as the back icon');
+  });
+
+  test('wrapperClass', async function (assert) {
+    await render(hbs`
+      <DenaliInput
+        @wrapperClass={{this.wrapperClass}}
+      />
+    `);
+
+    const wrapperClass = 'wrapperClass';
+    assert.dom('.input').doesNotHaveClass(wrapperClass, '`DenaliInput` does not have custom wrapper class by default');
+
+    this.set('wrapperClass', wrapperClass);
+
+    assert.dom('.input').hasClass(wrapperClass, '`DenaliInput` has custom specified wrapper class');
   });
 
   test('actions', async function (assert) {

--- a/tests/integration/components/denali-select-test.js
+++ b/tests/integration/components/denali-select-test.js
@@ -89,20 +89,30 @@ module('Integration | Component | denali-select', function (hooks) {
     );
   });
 
-  test('it supports small size', async function (assert) {
-    assert.expect(2);
-
+  test('it supports sizes', async function (assert) {
+    this.set('options', opts);
     await render(hbs`
-      <DenaliSelect @options={{this.options}} @isSmall={{this.isSmall}} as |option|>
+      <DenaliSelect 
+        @options={{this.options}} 
+        @size={{this.size}}
+        as |option|
+      >
         {{option.text}}
       </DenaliSelect>
     `);
 
-    this.set('options', opts);
-    assert.dom('div.input').doesNotHaveClass('is-small', 'DenaliSelect does not have small styling by default');
+    assert
+      .dom('.input')
+      .doesNotHaveClass(/is-small|is-medium|is-large/, 'DenaliSelect wrapper does not have a size class by default');
 
-    this.set('isSmall', 'true');
-    assert.dom('div.input').hasClass('is-small', 'DenaliSelect has a small size when `@isSmall` arg is set to true');
+    this.set('size', 'small');
+    assert.dom('.input').hasClass('is-small', 'DenaliSelect wrapper has the appropriate class for small');
+
+    this.set('size', 'medium');
+    assert.dom('.input').hasClass('is-medium', 'DenaliSelect wrapper has the appropriate class for medium');
+
+    this.set('size', 'large');
+    assert.dom('.input').hasClass('is-large', 'DenaliSelect wrapper has the appropriate class for large');
   });
 
   test('it supports inverse colors', async function (assert) {

--- a/tests/integration/components/denali-tag-test.js
+++ b/tests/integration/components/denali-tag-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | denali-tag', function (hooks) {
@@ -61,10 +61,16 @@ module('Integration | Component | denali-tag', function (hooks) {
   });
 
   test('icons', async function (assert) {
+    assert.expect(12);
+
     await render(hbs`
       <DenaliTag
         @iconFront={{this.iconFront}}
+        @iconFrontClass={{this.iconFrontClass}}
+        @onIconFrontClick={{this.onIconFrontClick}}
         @iconBack={{this.iconBack}}
+        @iconBackClass={{this.iconBackClass}}
+        @onIconBackClick={{this.onIconBackClick}}
       >Tag Content</DenaliTag>
     `);
 
@@ -81,12 +87,34 @@ module('Integration | Component | denali-tag', function (hooks) {
       .hasClass('has-icon-front', 'DenaliTag has the `has-icon-front` class when iconFront is specified');
     assert.dom('span.tag .d-icon').hasClass('d-check', 'DenaliTag has the specified icon in the front');
 
+    const iconFrontClass = 'iconFrontClass';
+    assert
+      .dom('span.tag .d-icon')
+      .doesNotHaveClass(iconFrontClass, 'DenaliTag does not have `iconFrontClass` class by default');
+    this.set('iconFrontClass', iconFrontClass);
+    assert.dom('span.tag .d-check').hasClass(iconFrontClass, 'DenaliTag has the specified `iconFrontClass`');
+
+    this.set('onIconFrontClick', () => assert.ok(true, '`onIconFrontClick` fires on click'));
+    await click('.d-check');
+
     // unset the front icon to check the back icon
     this.set('iconFront', undefined);
+    this.set('onIconFrontClick', undefined);
+
     this.set('iconBack', 'close');
     assert
       .dom('span.tag')
       .hasClass('has-icon-back', 'DenaliTag has the `has-icon-back` class when iconBack is specified');
-    assert.dom('span.tag .d-icon').hasClass('d-close', 'test');
+    assert.dom('span.tag .d-icon').hasClass('d-close', 'DenaliTag has the specified icon in the back');
+
+    const iconBackClass = 'iconBackClass';
+    assert
+      .dom('span.tag .d-close')
+      .doesNotHaveClass(iconBackClass, 'DenaliTag does not have `iconBackClass` class by default');
+    this.set('iconBackClass', iconBackClass);
+    assert.dom('span.tag .d-icon').hasClass(iconBackClass, 'DenaliTag has the specified `iconBackClass`');
+
+    this.set('onIconBackClick', () => assert.ok(true, '`onIconBackClick` fires on click'));
+    await click('.d-close');
   });
 });


### PR DESCRIPTION
- feat: groups, disabled, scrolling, & size support
  - BREAKING CHANGE: size classes moved to `triggerClass` arg to support `renderInPlace` true & false
- feat: add `wrapperClass` arg to `DenaliInput`
- feat: add DenaliTag icon classes and click actions
- docs: add DenaliButton icon, iconOnly to storybook
- feat: support more size in DenaliSelect
  - BREAKING CHANGE: `isSmall` arg has been replaced with `size` arg to support more sizes