### PR TITLE
feat: update to denali-2.3.0

### DIFF
--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -97,7 +97,7 @@
 
 .ember-power-select-group-name {
   text-transform: uppercase;
-  color: $color-grey-700;
+  color: map-get($denali-grey-colors, '700');
   font-size: 12px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18955,9 +18955,9 @@
       "dev": true
     },
     "denali-css": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/denali-css/-/denali-css-2.2.3.tgz",
-      "integrity": "sha512-a5qXJSU7RD7uue3wosZHHn4DG9CVDHh/sMe3y86ypmmelUosccluS4a1uswuqRe7A2GL1OpLvYC32GpMSW3qog=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/denali-css/-/denali-css-2.3.0.tgz",
+      "integrity": "sha512-xVm3vgtGEPmS12zOiqQk5+XxhpXGodSIKaiTv0JTDeulmCeini7M5Uqe8MG+ePQPk+5RdLtGNMWJyYMsa/yE9w=="
     },
     "denali-icon-font": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@glimmer/tracking": "^1.0.3",
     "broccoli-funnel": "^3.0.1",
     "broccoli-merge-trees": "^4.1.0",
-    "denali-css": "^2.2.3",
+    "denali-css": "^2.3.0",
     "denali-icon-font": "^1.7.0",
     "ember-arg-types": "^0.2.1",
     "ember-cli-babel": "^7.23.0",


### PR DESCRIPTION
This PR brings in the latest denali-css, plus removes use of `denali-grey-colors` which is no longer available.