### PR TITLE
css change to fix double scrollbars in power select dropdown

### DIFF
--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -88,6 +88,7 @@
   .ember-power-select-option {
     padding: 8px 16px;
   }
+
   .ember-power-select-options {
     max-height: max-content;
     overflow-y: hidden;

--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -89,6 +89,7 @@
     padding: 8px 16px;
   }
 
+
   .ember-power-select-options {
     max-height: max-content;
     overflow-y: hidden;

--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -88,6 +88,10 @@
   .ember-power-select-option {
     padding: 8px 16px;
   }
+  .ember-power-select-options {
+    max-height: max-content;
+    overflow-y: hidden;
+  }
 }
 
 .ember-power-select-group-name {

--- a/app/styles/denali/ember-power-select.scss
+++ b/app/styles/denali/ember-power-select.scss
@@ -89,7 +89,6 @@
     padding: 8px 16px;
   }
 
-
   .ember-power-select-options {
     max-height: max-content;
     overflow-y: hidden;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,7 +5652,20 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.1, broccoli-funnel@^3.0.3:
+broccoli-funnel@^3.0.1:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
+  integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==
+  dependencies:
+    array-equal "^1.0.0"
+    broccoli-plugin "^4.0.7"
+    debug "^4.1.1"
+    fs-tree-diff "^2.0.1"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    walk-sync "^2.0.2"
+
+broccoli-funnel@^3.0.3:
   version "3.0.5"
   resolved "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.5.tgz#60da33d060fae2936b3d78217bd4008a6eea5e41"
   integrity sha512-fcjvQIWq4lpKyzQ7FWRo/V8/nOALjIrAoRMFCLgFeO2xhOC1+i7QWbMndLTwpnLCoXpTa+luBu3WSFoxQ3VPlw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,20 +5652,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.1:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
-  integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==
-  dependencies:
-    array-equal "^1.0.0"
-    broccoli-plugin "^4.0.7"
-    debug "^4.1.1"
-    fs-tree-diff "^2.0.1"
-    heimdalljs "^0.2.0"
-    minimatch "^3.0.0"
-    walk-sync "^2.0.2"
-
-broccoli-funnel@^3.0.3:
+broccoli-funnel@^3.0.1, broccoli-funnel@^3.0.3:
   version "3.0.5"
   resolved "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.5.tgz#60da33d060fae2936b3d78217bd4008a6eea5e41"
   integrity sha512-fcjvQIWq4lpKyzQ7FWRo/V8/nOALjIrAoRMFCLgFeO2xhOC1+i7QWbMndLTwpnLCoXpTa+luBu3WSFoxQ3VPlw==


### PR DESCRIPTION
Power select dropdown shows double scrollbars  when there are more than a few options for a groupname. This style change will remove the scrollbar and also allow for all the options under each groupname to be shown.
Before
![filters scrollbars](https://user-images.githubusercontent.com/59849444/131138121-dc6b0407-4de3-4586-9923-cf07d9ca727a.png)
After
<img width="463" alt="Screen Shot 2021-08-25 at 9 27 40 PM" src="https://user-images.githubusercontent.com/59849444/131138164-6fa3505e-6ad8-49cd-bdf0-82ae8fa36214.png">
